### PR TITLE
Moved ConnectableDevicePairingLevel static property to the DeviceService class https://github.com/ConnectSDK/Connect-SDK-Android/issues/121

### DIFF
--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -38,6 +38,7 @@ import com.connectsdk.core.Util;
 import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.service.DeviceService;
 import com.connectsdk.service.DeviceService.DeviceServiceListener;
+import com.connectsdk.service.DeviceService.PairingLevel;
 import com.connectsdk.service.DeviceService.PairingType;
 import com.connectsdk.service.capability.CapabilityMethods;
 import com.connectsdk.service.capability.ExternalInputControl;
@@ -777,6 +778,39 @@ public class ConnectableDevice implements DeviceServiceListener {
             this.id = java.util.UUID.randomUUID().toString();
 
         return this.id;
+    }
+    
+    /**
+     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
+     *
+     * If pairingLevel is set to PairingLevel.On, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
+     *
+     * If pairingLevel is set to PairingLevel.Off (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
+     */
+    public PairingLevel getPairingLevel() {
+        PairingLevel pairingLevel = PairingLevel.OFF;
+        
+        for (DeviceService service : getServices()) {
+            if (service.getPairingLevel() == PairingLevel.ON) {
+                pairingLevel = PairingLevel.ON;
+                break;
+            }
+        }
+        
+        return pairingLevel;
+    }
+
+    /**
+     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
+     *
+     * If pairingLevel is set to PairingLevel.On, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
+     *
+     * If pairingLevel is set to PairingLevel.Off (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
+     */
+    public void setPairingLevel(PairingLevel pairingLevel) {
+        for (DeviceService service : getServices()) {
+            service.setPairingLevel(pairingLevel);
+        }
     }
 
     // @cond INTERNAL

--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -87,11 +87,6 @@ import com.connectsdk.service.config.ServiceDescription;
  */
 public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryProviderListener, ServiceConfigListener {
 
-    public enum PairingLevel {
-        OFF,
-        ON
-    }
-
     // @cond INTERNAL
 
     public static String CONNECT_SDK_VERSION = "1.4";
@@ -117,8 +112,6 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
     boolean isBroadcastReceiverRegistered = false;
 
     Timer rescanTimer;
-
-    PairingLevel pairingLevel;
 
     private boolean mSearching = false;
 
@@ -195,7 +188,6 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
         multicastLock.setReferenceCounted(true);
 
         capabilityFilters = new ArrayList<CapabilityFilter>();
-        pairingLevel = PairingLevel.OFF;
 
         receiver = new BroadcastReceiver() { 
 
@@ -634,28 +626,6 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      */
     public Map<String, ConnectableDevice> getCompatibleDevices() {
         return compatibleDevices;
-    }
-
-    /**
-     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
-     *
-     * If pairingLevel is set to ConnectableDevicePairingLevelOn, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
-     *
-     * If pairingLevel is set to ConnectableDevicePairingLevelOff (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
-     */
-    public PairingLevel getPairingLevel() {
-        return pairingLevel;
-    }
-
-    /**
-     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
-     *
-     * If pairingLevel is set to ConnectableDevicePairingLevelOn, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
-     *
-     * If pairingLevel is set to ConnectableDevicePairingLevelOff (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
-     */
-    public void setPairingLevel(PairingLevel pairingLevel) {
-        this.pairingLevel = pairingLevel;
     }
 
     // @cond INTERNAL

--- a/src/com/connectsdk/service/DeviceService.java
+++ b/src/com/connectsdk/service/DeviceService.java
@@ -44,10 +44,10 @@ import com.connectsdk.service.capability.MediaPlayer;
 import com.connectsdk.service.capability.WebAppLauncher;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
+import com.connectsdk.service.command.ServiceCommand.ServiceCommandProcessor;
 import com.connectsdk.service.command.ServiceCommandError;
 import com.connectsdk.service.command.ServiceSubscription;
 import com.connectsdk.service.command.URLServiceSubscription;
-import com.connectsdk.service.command.ServiceCommand.ServiceCommandProcessor;
 import com.connectsdk.service.config.ServiceConfig;
 import com.connectsdk.service.config.ServiceDescription;
 import com.connectsdk.service.sessions.LaunchSession;
@@ -73,6 +73,11 @@ public class DeviceService implements DeviceServiceReachabilityListener, Service
         FIRST_SCREEN,
         PIN_CODE
     }
+    
+    public enum PairingLevel {
+        OFF,
+        ON
+    }
 
     // @cond INTERNAL
     public static final String KEY_CLASS = "class";
@@ -84,6 +89,9 @@ public class DeviceService implements DeviceServiceReachabilityListener, Service
 
     protected DeviceServiceReachability mServiceReachability;
     protected boolean connected = false;
+    
+    PairingLevel pairingLevel = PairingLevel.OFF;
+
     // @endcond
 
     /**
@@ -596,6 +604,30 @@ public class DeviceService implements DeviceServiceReachabilityListener, Service
     //  Unused by default.
     @Override public void onLoseReachability(DeviceServiceReachability reachability) { }
     // @endcond
+    
+    /**
+     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
+     *
+     * If pairingLevel is set to PairingLevel.On, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
+     *
+     * If pairingLevel is set to PairingLevel.Off (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
+     */
+    public PairingLevel getPairingLevel() {
+        return pairingLevel;
+    }
+
+    /**
+     * The pairingLevel property determines whether capabilities that require pairing (such as entering a PIN) will be available.
+     *
+     * If pairingLevel is set to PairingLevel.On, ConnectableDevices that require pairing will prompt the user to pair when connecting to the ConnectableDevice.
+     *
+     * If pairingLevel is set to PairingLevel.Off (the default), connecting to the device will avoid requiring pairing if possible but some capabilities may not be available.
+     */
+    public void setPairingLevel(PairingLevel pairingLevel) {
+        this.pairingLevel = pairingLevel;
+        
+        updateCapabilities();
+    }
 
     public interface DeviceServiceListener {
 

--- a/src/com/connectsdk/service/NetcastTVService.java
+++ b/src/com/connectsdk/service/NetcastTVService.java
@@ -63,9 +63,9 @@ import com.connectsdk.core.Util;
 import com.connectsdk.device.ConnectableDevice;
 import com.connectsdk.discovery.DiscoveryFilter;
 import com.connectsdk.discovery.DiscoveryManager;
-import com.connectsdk.discovery.DiscoveryManager.PairingLevel;
 import com.connectsdk.etc.helper.DeviceServiceReachability;
 import com.connectsdk.etc.helper.HttpMessage;
+import com.connectsdk.service.DeviceService.PairingLevel;
 import com.connectsdk.service.capability.ExternalInputControl;
 import com.connectsdk.service.capability.KeyControl;
 import com.connectsdk.service.capability.Launcher;
@@ -190,7 +190,7 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
             serviceConfig.setListener(DiscoveryManager.getInstance());
         }
 
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+        if (getPairingLevel() == PairingLevel.ON) {
             if (((NetcastTVServiceConfig) serviceConfig).getPairingKey() != null 
                     && ((NetcastTVServiceConfig)serviceConfig).getPairingKey().length() != 0) {
 
@@ -1562,7 +1562,7 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
      *****************/
     @Override
     public MediaControl getMediaControl() {
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.OFF)
+        if (getPairingLevel() == PairingLevel.OFF)
             return this.getDLNAService();
         else
             return this;
@@ -2292,7 +2292,7 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
     protected void updateCapabilities() {
         List<String> capabilities = new ArrayList<String>();
 
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+        if (getPairingLevel() == PairingLevel.ON) {
             for (String capability : TextInputControl.Capabilities) { capabilities.add(capability); }
             for (String capability : MouseControl.Capabilities) { capabilities.add(capability); }
             for (String capability : KeyControl.Capabilities) { capabilities.add(capability); }

--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -40,7 +40,6 @@ import com.connectsdk.core.Util;
 import com.connectsdk.device.ConnectableDevice;
 import com.connectsdk.discovery.DiscoveryFilter;
 import com.connectsdk.discovery.DiscoveryManager;
-import com.connectsdk.discovery.DiscoveryManager.PairingLevel;
 import com.connectsdk.service.capability.ExternalInputControl;
 import com.connectsdk.service.capability.KeyControl;
 import com.connectsdk.service.capability.Launcher;
@@ -258,7 +257,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
 
     @Override
     public boolean isConnected() {
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+        if (getPairingLevel() == PairingLevel.ON) {
             return this.socket != null && this.socket.isConnected() && (((WebOSTVServiceConfig)serviceConfig).getClientKey() != null);
         } else {
             return this.socket != null && this.socket.isConnected();
@@ -375,7 +374,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
 
         @Override
         public void onBeforeRegister(final PairingType pairingType) {
-            if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+            if (getPairingLevel() == PairingLevel.ON) {
                 Util.runOnUI(new Runnable() {
 
                     @Override
@@ -2733,12 +2732,20 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
         if (socket != null)
             socket.unsubscribe(subscription);
     }
+    
+    public PairingType getPairingType() {
+        return pairingType;
+    }
+    
+    public void setPairingType(PairingType pairingType) {
+        this.pairingType = pairingType;
+    }
 
     @Override
     protected void updateCapabilities() {
         List<String> capabilities = new ArrayList<String>();
 
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+        if (getPairingLevel() == PairingLevel.ON) {
             for (String capability : TextInputControl.Capabilities) { capabilities.add(capability); }
             for (String capability : MouseControl.Capabilities) { capabilities.add(capability); }
             for (String capability : KeyControl.Capabilities) { capabilities.add(capability); }
@@ -2807,7 +2814,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
             defaultPermissions.add(perm);
         }
 
-        if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+        if (getPairingLevel() == PairingLevel.ON) {
             for (String perm: kWebOSTVServiceProtectedPermissions) {
                 defaultPermissions.add(perm);
             }

--- a/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
+++ b/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
@@ -469,6 +469,10 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
             if (((WebOSTVServiceConfig)mService.getServiceConfig()).getClientKey() != null) {
                 payload.put("client-key", ((WebOSTVServiceConfig)mService.getServiceConfig()).getClientKey());
             }
+            
+            if (mService.getPairingType() == PairingType.PIN_CODE) {
+                payload.put("pairingType", "PIN");
+            }
 
             if (manifest != null) {
                 payload.put("manifest", manifest);


### PR DESCRIPTION
Moved ConnectableDevicePairingLevel static property to the DeviceService class.

Now we can choose pairingType for webOSTV (PROMPT / PIN_CODE)