### PR TITLE
Add equals and hashCode methods to DiscoveryFilter

### DIFF
--- a/src/com/connectsdk/discovery/DiscoveryFilter.java
+++ b/src/com/connectsdk/discovery/DiscoveryFilter.java
@@ -32,10 +32,9 @@ public class DiscoveryFilter {
 
         DiscoveryFilter that = (DiscoveryFilter) o;
 
-        if (serviceFilter != null ? !serviceFilter.equals(that.serviceFilter) : that.serviceFilter != null)
+        if (serviceId != null ? !serviceId.equals(that.serviceId) : that.serviceId != null) {
             return false;
-        if (serviceId != null ? !serviceId.equals(that.serviceId) : that.serviceId != null)
-            return false;
+        }
 
         return true;
     }
@@ -43,7 +42,6 @@ public class DiscoveryFilter {
     @Override
     public int hashCode() {
         int result = serviceId != null ? serviceId.hashCode() : 0;
-        result = 31 * result + (serviceFilter != null ? serviceFilter.hashCode() : 0);
         return result;
     }
 }

--- a/src/com/connectsdk/discovery/DiscoveryFilter.java
+++ b/src/com/connectsdk/discovery/DiscoveryFilter.java
@@ -24,4 +24,26 @@ public class DiscoveryFilter {
     public void setServiceFilter(String serviceFilter) {
         this.serviceFilter = serviceFilter;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DiscoveryFilter that = (DiscoveryFilter) o;
+
+        if (serviceFilter != null ? !serviceFilter.equals(that.serviceFilter) : that.serviceFilter != null)
+            return false;
+        if (serviceId != null ? !serviceId.equals(that.serviceId) : that.serviceId != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serviceId != null ? serviceId.hashCode() : 0;
+        result = 31 * result + (serviceFilter != null ? serviceFilter.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/com/connectsdk/discovery/DiscoveryFilter.java
+++ b/src/com/connectsdk/discovery/DiscoveryFilter.java
@@ -32,9 +32,10 @@ public class DiscoveryFilter {
 
         DiscoveryFilter that = (DiscoveryFilter) o;
 
-        if (serviceId != null ? !serviceId.equals(that.serviceId) : that.serviceId != null) {
+        if (serviceFilter != null ? !serviceFilter.equals(that.serviceFilter) : that.serviceFilter != null)
             return false;
-        }
+        if (serviceId != null ? !serviceId.equals(that.serviceId) : that.serviceId != null)
+            return false;
 
         return true;
     }
@@ -42,6 +43,7 @@ public class DiscoveryFilter {
     @Override
     public int hashCode() {
         int result = serviceId != null ? serviceId.hashCode() : 0;
+        result = 31 * result + (serviceFilter != null ? serviceFilter.hashCode() : 0);
         return result;
     }
 }

--- a/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
@@ -228,48 +228,13 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
         if (filter.getServiceFilter() == null) {
             Log.e("Connect SDK", "This device filter does not have ssdp filter info");
         } else {
-//            String newFilter = null;
-//            try {
-//                newFilter = parameters.getString("filter");
-//                for (int i = 0; i < serviceFilters.size(); i++) { 
-//                    String filter = serviceFilters.get(i).getString("filter");
-//
-//                    if (newFilter.equals(filter)) 
-//                        return;
-//                }
-//            } catch (JSONException e) {
-//                e.printStackTrace();
-//            }
-
             serviceFilters.add(filter);
-
-//            if (newFilter != null)
-//                controlPoint.addFilter(newFilter);
         }
     }
 
     @Override
     public void removeDeviceFilter(DiscoveryFilter filter) {
-        String removalServiceId;
-        boolean shouldRemove = false;
-        int removalIndex = -1;
-
-        removalServiceId = filter.getServiceId();
-
-        for (int i = 0; i < serviceFilters.size(); i++) {
-            DiscoveryFilter serviceFilter = serviceFilters.get(i);
-            String serviceId = serviceFilter.getServiceId();
-
-            if (serviceId.equals(removalServiceId)) {
-                shouldRemove = true;
-                removalIndex = i;
-                break;
-            }
-        }
-
-        if (shouldRemove) {
-            serviceFilters.remove(removalIndex);
-        }
+        serviceFilters.remove(filter);
     }
 
     @Override

--- a/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
@@ -279,26 +279,7 @@ public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
 
     @Override
     public void removeDeviceFilter(DiscoveryFilter filter) {
-        String removalServiceId;
-        boolean shouldRemove = false;
-        int removalIndex = -1;
-
-        removalServiceId = filter.getServiceId();
-
-        for (int i = 0; i < serviceFilters.size(); i++) {
-            DiscoveryFilter serviceFilter = serviceFilters.get(i);
-            String serviceId = serviceFilter.getServiceId();
-
-            if (serviceId.equals(removalServiceId)) {
-                shouldRemove = true;
-                removalIndex = i;
-                break;
-            }
-        }
-
-        if (shouldRemove) {
-            serviceFilters.remove(removalIndex);
-        }
+        serviceFilters.remove(filter);
     }
 
     @Override

--- a/test/src/com/connectsdk/discovery/DiscoveryFilterParameterizedTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryFilterParameterizedTest.java
@@ -21,7 +21,6 @@ public class DiscoveryFilterParameterizedTest {
     private final String mIdB;
     private final String mFilterB;
     private final Boolean mResult;
-    private Map<String, String> parameters;
     
     @Parameterized.Parameters
     public static Collection<Object[]> configs() {

--- a/test/src/com/connectsdk/discovery/DiscoveryFilterParameterizedTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryFilterParameterizedTest.java
@@ -1,0 +1,61 @@
+package com.connectsdk.discovery;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Created by oleksii.frolov on 2/12/2015.
+ */
+@RunWith(Parameterized.class)
+public class DiscoveryFilterParameterizedTest {
+
+    private final String mIdA;
+    private final String mFilterA;
+    private final String mIdB;
+    private final String mFilterB;
+    private final Boolean mResult;
+    private Map<String, String> parameters;
+    
+    @Parameterized.Parameters
+    public static Collection<Object[]> configs() {
+        return Arrays.asList(new Object[][] {
+                {"id", "filter", "id", "filter", Boolean.TRUE},
+                {"id", "filter", "id", "another", Boolean.FALSE},
+                {"id", "filter", "another", "filter", Boolean.FALSE},
+                {null, "filter", null, "filter", Boolean.TRUE},
+                {"id", null, "id", null, Boolean.TRUE},
+                {null, null, null, null, Boolean.TRUE},
+                {"id", "filter", null, "filter", Boolean.FALSE},
+        });         
+    }
+    
+    public DiscoveryFilterParameterizedTest(String idA, String filterA, String idB, String filterB, Boolean result) {
+        this.mIdA = idA;
+        this.mFilterA = filterA;
+        this.mIdB = idB;
+        this.mFilterB = filterB;
+        this.mResult = result;
+    }
+    
+    @Test
+    public void testEquals() {
+        DiscoveryFilter filterA = new DiscoveryFilter(mIdA, mFilterA);
+        DiscoveryFilter filterB = new DiscoveryFilter(mIdB, mFilterB);
+        Assert.assertEquals(mResult.booleanValue(), filterA.equals(filterB));
+        Assert.assertEquals(mResult.booleanValue(), filterB.equals(filterA));
+    }
+
+    @Test
+    public void testHashCode() {
+        DiscoveryFilter filterA = new DiscoveryFilter(mIdA, mFilterA);
+        DiscoveryFilter filterB = new DiscoveryFilter(mIdB, mFilterB);
+        Assert.assertEquals(mResult.booleanValue(), filterA.hashCode() == filterB.hashCode());
+    }
+}

--- a/test/src/com/connectsdk/discovery/provider/DiscoveryFilterTest.java
+++ b/test/src/com/connectsdk/discovery/provider/DiscoveryFilterTest.java
@@ -1,0 +1,25 @@
+package com.connectsdk.discovery.provider;
+
+import com.connectsdk.discovery.DiscoveryFilter;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Created by oleksii.frolov on 2/12/2015.
+ */
+public class DiscoveryFilterTest {
+    
+    @Test
+    public void testEqualsWithNullObject() {
+        DiscoveryFilter filter = new DiscoveryFilter("DLNA", "filter");
+        Assert.assertFalse(filter.equals(null));
+    }
+
+    @Test
+    public void testEqualsWithWrongObject() {
+        DiscoveryFilter filter = new DiscoveryFilter("DLNA", "filter");
+        Assert.assertFalse(filter.equals(new Object()));
+    }
+}

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -113,7 +113,30 @@ public class SSDPDiscoveryProviderTest{
         dp.serviceFilters.add(filter);
         dp.removeDeviceFilter(filter);
         Assert.assertFalse(dp.serviceFilters.contains(filter));
+    }
 
+    @Test
+    public void testRemoveDeviceFiltersWithEmptyFilterString() throws JSONException {
+        DiscoveryFilter filter = new DiscoveryFilter("DLNA", null);
+        dp.serviceFilters.add(filter);
+        dp.removeDeviceFilter(filter);
+        Assert.assertFalse(dp.serviceFilters.contains(filter));
+    }
+
+    @Test
+    public void testRemoveDeviceFiltersWithEmptyId() throws JSONException {
+        DiscoveryFilter filter = new DiscoveryFilter(null, "urn:schemas-upnp-org:device:MediaRenderer:1");
+        dp.serviceFilters.add(filter);
+        dp.removeDeviceFilter(filter);
+        Assert.assertFalse(dp.serviceFilters.contains(filter));
+    }
+
+    @Test
+    public void testRemoveDeviceFiltersWithDifferentFilterStrings() throws JSONException {
+        DiscoveryFilter filter = new DiscoveryFilter("DLNA", "urn:schemas-upnp-org:device:MediaRenderer:1");
+        dp.serviceFilters.add(filter);
+        dp.removeDeviceFilter(new DiscoveryFilter("DLNA", null));
+        Assert.assertTrue(dp.serviceFilters.contains(filter));
     }
 
     @Test

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -136,7 +136,7 @@ public class SSDPDiscoveryProviderTest{
         DiscoveryFilter filter = new DiscoveryFilter("DLNA", "urn:schemas-upnp-org:device:MediaRenderer:1");
         dp.serviceFilters.add(filter);
         dp.removeDeviceFilter(new DiscoveryFilter("DLNA", null));
-        Assert.assertFalse(dp.serviceFilters.contains(filter));
+        Assert.assertTrue(dp.serviceFilters.contains(filter));
     }
 
     @Test

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -136,7 +136,7 @@ public class SSDPDiscoveryProviderTest{
         DiscoveryFilter filter = new DiscoveryFilter("DLNA", "urn:schemas-upnp-org:device:MediaRenderer:1");
         dp.serviceFilters.add(filter);
         dp.removeDeviceFilter(new DiscoveryFilter("DLNA", null));
-        Assert.assertTrue(dp.serviceFilters.contains(filter));
+        Assert.assertFalse(dp.serviceFilters.contains(filter));
     }
 
     @Test


### PR DESCRIPTION
It's simplified SSDPDiscoveryProvider removeDeviceFilter method and added equals/hashCode methods into DiscoveryFilter. There are also some new test for checking this method. It is based on the comment https://github.com/ConnectSDK/Connect-SDK-Android-Core/commit/5d16c5bb976c35c89b0682009b8de6812e69f0c9#commitcomment-9689474