### PR TITLE
Added full pin pairing support for webos

### DIFF
--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -328,7 +328,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
                 @Override
                 public void run() {
                     if (listener != null)
-                        listener.onConnectionFailure(WebOSTVService.this, error);
+                        listener.onPairingFailed(WebOSTVService.this, error);
                 }
             });
         }
@@ -2307,7 +2307,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
 
     private void notifyPairingRequired() {
         if (listener != null) {
-            listener.onPairingRequired(this, PairingType.FIRST_SCREEN, null);
+            listener.onPairingRequired(this, pairingType, null);
         }
     }
 
@@ -2835,6 +2835,14 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
                 disconnect();
             }
         }
+    }
+    
+    public PairingType getPairingType(){
+    	return pairingType;
+    }
+    
+    public void setPairingType(PairingType pairingType){
+    	this.pairingType=pairingType;
     }
 
     private ChannelInfo parseRawChannelData(JSONObject channelRawData) {

--- a/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
+++ b/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
@@ -473,6 +473,11 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
                 payload.put("client-key", ((WebOSTVServiceConfig)mService.getServiceConfig()).getClientKey());
             }
 
+            if (mService.getPairingType()!=null&&mService.getPairingType().equals(PairingType.PIN_CODE)){
+				payload.put("forcePairing", false);
+				payload.put("pairingType", "PIN");
+			}
+            
             if (manifest != null) {
                 payload.put("manifest", manifest);
             }
@@ -493,7 +498,7 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
                 state = State.INITIAL;
                 
                 if (mListener != null)
-                    mListener.onFailWithError(error);
+                    mListener.onRegistrationFailed(error);
             }
 
             @Override


### PR DESCRIPTION
Added full support for webos pin pairing method, the method is configured through the service itself as the connectable device should be pairing type agnostic.
Another point is the error handling, I needed to change the error callbacks to receive the correct events in the connecteddevicelistenrer, since the previous method resulted in no indication if the registration failed or canceld.