### PR TITLE
Add set pairing type to DeviceService and ConnectableDevice

### DIFF
--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -22,7 +22,6 @@ package com.connectsdk.device;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -22,6 +22,7 @@ package com.connectsdk.device;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -150,6 +151,17 @@ public class ConnectableDevice implements DeviceServiceListener {
         this.serviceDescription = serviceDescription;
     }
     // @endcond
+
+    /**
+     * set desirable pairing type for all services
+     * @param pairingType
+     */
+    public void setPairingType(PairingType pairingType) {
+        Collection<DeviceService> services = getServices();
+        for (DeviceService service : services) {
+            service.setPairingType(pairingType);
+        }
+    }
 
     /**
      * Adds a DeviceService to the ConnectableDevice instance. Only one instance of each DeviceService type (webOS, Netcast, etc) may be attached to a single ConnectableDevice instance. If a device contains your service type already, your service will not be added.

--- a/src/com/connectsdk/service/DeviceService.java
+++ b/src/com/connectsdk/service/DeviceService.java
@@ -80,7 +80,10 @@ public class DeviceService implements DeviceServiceReachabilityListener, Service
     public static final String KEY_CONFIG = "config";
     public static final String KEY_DESC = "description";
 
+    PairingType pairingType = PairingType.NONE;
+
     ServiceDescription serviceDescription;
+
     ServiceConfig serviceConfig;
 
     protected DeviceServiceReachability mServiceReachability;
@@ -204,6 +207,13 @@ public class DeviceService implements DeviceServiceReachabilityListener, Service
         }
 
         return null;
+    }
+
+    public PairingType getPairingType() {
+        return pairingType;
+    }
+
+    public void setPairingType(PairingType pairingType) {
     }
 
     @SuppressWarnings("unchecked")

--- a/src/com/connectsdk/service/NetcastTVService.java
+++ b/src/com/connectsdk/service/NetcastTVService.java
@@ -150,6 +150,8 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
     public NetcastTVService(ServiceDescription serviceDescription, ServiceConfig serviceConfig) {
         super(serviceDescription, serviceConfig);
 
+        pairingType = PairingType.PIN_CODE;
+
         if (serviceDescription.getPort() != 8080)
             serviceDescription.setPort(8080);
 
@@ -322,7 +324,7 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
             @Override
             public void onSuccess(Object response) {
                 if (listener != null)
-                    listener.onPairingRequired(NetcastTVService.this, PairingType.PIN_CODE, null);
+                    listener.onPairingRequired(NetcastTVService.this, pairingType, null);
             }
 
             @Override

--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.java_websocket.client.WebSocketClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -202,20 +201,18 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
 
     WebOSTVMouseSocketConnection mouseSocket;
 
-    WebSocketClient mouseWebSocket;
     WebOSTVKeyboardInput keyboardInput;
 
     ConcurrentHashMap<String, String> mAppToAppIdMappings;
+
     ConcurrentHashMap<String, WebOSWebAppSession> mWebAppSessions;
 
     WebOSTVServiceSocketClient socket;
-    PairingType pairingType;
 
     List<String> permissions;
 
     public WebOSTVService(ServiceDescription serviceDescription, ServiceConfig serviceConfig) {
         super(serviceDescription, serviceConfig);
-
         setServiceDescription(serviceDescription);
 
         pairingType = PairingType.FIRST_SCREEN;
@@ -224,6 +221,10 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
         mWebAppSessions = new ConcurrentHashMap<String, WebOSWebAppSession>();
     }
 
+    @Override
+    public void setPairingType(PairingType pairingType) {
+        this.pairingType = pairingType;
+    }
 
     @Override
     public CapabilityPriorityLevel getPriorityLevel(Class<? extends CapabilityMethods> clazz) {
@@ -2441,7 +2442,7 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
 
     private void notifyPairingRequired() {
         if (listener != null) {
-            listener.onPairingRequired(this, PairingType.FIRST_SCREEN, null);
+            listener.onPairingRequired(this, pairingType, null);
         }
     }
 

--- a/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
+++ b/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
@@ -472,6 +472,10 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
                 payload.put("client-key", ((WebOSTVServiceConfig)mService.getServiceConfig()).getClientKey());
             }
 
+            if (PairingType.PIN_CODE.equals(mService.getPairingType())) {
+                payload.put("pairingType", "PIN");
+            }
+
             if (manifest != null) {
                 payload.put("manifest", manifest);
             }

--- a/test/src/com/connectsdk/device/ConnectableDeviceTest.java
+++ b/test/src/com/connectsdk/device/ConnectableDeviceTest.java
@@ -1,8 +1,17 @@
 package com.connectsdk.device;
 
+import com.connectsdk.discovery.DiscoveryManager;
+import com.connectsdk.service.AirPlayService;
+import com.connectsdk.service.DIALService;
+import com.connectsdk.service.DLNAService;
 import com.connectsdk.service.DeviceService;
+import com.connectsdk.service.NetcastTVService;
+import com.connectsdk.service.RokuService;
+import com.connectsdk.service.WebOSTVService;
 import com.connectsdk.service.capability.Launcher;
 import com.connectsdk.service.capability.MediaPlayer;
+import com.connectsdk.service.config.ServiceConfig;
+import com.connectsdk.service.config.ServiceDescription;
 
 import junit.framework.Assert;
 
@@ -10,9 +19,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +35,7 @@ public class ConnectableDeviceTest {
 
     @Before
     public void setUp() {
+        DiscoveryManager.init(Robolectric.application);
         device = new ConnectableDevice();
     }
 
@@ -72,5 +84,82 @@ public class ConnectableDeviceTest {
         Assert.assertTrue(device.hasCapabilities(capabilities));
     }
 
+    @Test
+    public void testSetPromptPairingType() throws IOException {
+        // given
+        addAllCoreServicesToDevice();
+
+        // when
+        device.setPairingType(DeviceService.PairingType.FIRST_SCREEN);
+
+        // then
+        Assert.assertEquals(DeviceService.PairingType.FIRST_SCREEN, device.getServiceByName(WebOSTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.PIN_CODE, device.getServiceByName(NetcastTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DLNAService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DIALService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(RokuService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(AirPlayService.ID).getPairingType());
+    }
+
+    @Test
+    public void testSetPinPairingType() throws IOException {
+        // given
+        addAllCoreServicesToDevice();
+
+        // when
+        device.setPairingType(DeviceService.PairingType.PIN_CODE);
+
+        // then
+        Assert.assertEquals(DeviceService.PairingType.PIN_CODE, device.getServiceByName(WebOSTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.PIN_CODE, device.getServiceByName(NetcastTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DLNAService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DIALService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(RokuService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(AirPlayService.ID).getPairingType());
+    }
+
+    @Test
+    public void testNonePairingType() throws IOException {
+        // given
+        addAllCoreServicesToDevice();
+
+        // when
+        device.setPairingType(DeviceService.PairingType.NONE);
+
+        // then
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(WebOSTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.PIN_CODE, device.getServiceByName(NetcastTVService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DLNAService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(DIALService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(RokuService.ID).getPairingType());
+        Assert.assertEquals(DeviceService.PairingType.NONE, device.getServiceByName(AirPlayService.ID).getPairingType());
+    }
+
+    private void addAllCoreServicesToDevice() throws IOException {
+        DeviceService webOSService = new WebOSTVService(createServiceDescription(WebOSTVService.ID), Mockito.mock(ServiceConfig.class));
+        DeviceService netCastService = new NetcastTVService(createServiceDescription(NetcastTVService.ID), Mockito.mock(ServiceConfig.class));
+        DeviceService dialService = new DIALService(createServiceDescription(DIALService.ID), Mockito.mock(ServiceConfig.class));
+        DeviceService dlnaSrevice = new DLNAService(createServiceDescription(DLNAService.ID), Mockito.mock(ServiceConfig.class));
+        DeviceService rokuService = new RokuService(createServiceDescription(RokuService.ID), Mockito.mock(ServiceConfig.class));
+        DeviceService airPlayService = new AirPlayService(createServiceDescription(AirPlayService.ID), Mockito.mock(ServiceConfig.class));
+        device.services.put(WebOSTVService.ID, webOSService);
+        device.services.put(NetcastTVService.ID, netCastService);
+        device.services.put(DIALService.ID, dialService);
+        device.services.put(DLNAService.ID, dlnaSrevice);
+        device.services.put(RokuService.ID, rokuService);
+        device.services.put(AirPlayService.ID, airPlayService);
+    }
+
+    private ServiceDescription createServiceDescription(String serviceId) {
+        ServiceDescription description = new ServiceDescription();
+        description.setFriendlyName("");
+        description.setManufacturer("");
+        description.setUUID("");
+        description.setModelDescription("");
+        description.setModelName("");
+        description.setModelNumber("");
+        description.setServiceID(serviceId);
+        return description;
+    }
 
 }

--- a/test/src/com/connectsdk/service/AirPlayServiceTest.java
+++ b/test/src/com/connectsdk/service/AirPlayServiceTest.java
@@ -95,4 +95,15 @@ public class AirPlayServiceTest {
             }
         });
     }
+
+    @Test
+    public void testInitialPairingType() {
+        Assert.assertEquals(DeviceService.PairingType.NONE, service.getPairingType());
+    }
+
+    @Test
+    public void testPairingTypeSetter() {
+        service.setPairingType(DeviceService.PairingType.PIN_CODE);
+        Assert.assertEquals(DeviceService.PairingType.NONE, service.getPairingType());
+    }
 }

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -204,6 +204,17 @@ public class DLNAServiceTest {
         Assert.assertEquals("http://192.168.1.0/controlURL", dlnaService.avTransportURL);
     }
 
+    @Test
+    public void testInitialPairingType() {
+        Assert.assertEquals(DeviceService.PairingType.NONE, service.getPairingType());
+    }
+
+    @Test
+    public void testPairingTypeSetter() {
+        service.setPairingType(DeviceService.PairingType.PIN_CODE);
+        Assert.assertEquals(DeviceService.PairingType.NONE, service.getPairingType());
+    }
+
     private DLNAService makeServiceWithControlURL(String base, String controlURL) {
         List<Service> services = new ArrayList<Service>();
         Service service = new Service();
@@ -216,4 +227,5 @@ public class DLNAServiceTest {
         Mockito.when(description.getServiceList()).thenReturn(services);
         return new DLNAService(description, Mockito.mock(ServiceConfig.class), Robolectric.application);
     }
+
 }


### PR DESCRIPTION
This pull request adds a method setPairingType to ConnectableDevice and to DeviceService and it can be used for example in this way in the Sampler method setupPicker:
```
    mTV = (ConnectableDevice)arg0.getItemAtPosition(arg2);
    mTV.addListener(deviceListener);
    mTV.setPairingType(PairingType.PIN_CODE);
    mTV.connect();
```