### PR TITLE
Stop DLNAHttpServer when service is disconnected

### DIFF
--- a/src/com/connectsdk/core/Util.java
+++ b/src/com/connectsdk/core/Util.java
@@ -42,17 +42,27 @@ import com.connectsdk.service.command.ServiceCommandError;
 
 public final class Util {
     static public String T = "Connect SDK";
+
     static private Handler handler;
+
     static private final int NUM_OF_THREADS = 20;
 
-    static private Executor executor = Executors.newFixedThreadPool(NUM_OF_THREADS, new ThreadFactory() {
-        @Override
-        public Thread newThread(Runnable r) {
-            Thread th = new Thread(r);
-            th.setName("2nd Screen BG");
-            return th;
-        }
-    });
+    static private Executor executor;
+
+    static {
+        createExecutor();
+    }
+
+    static void createExecutor() {
+        Util.executor = Executors.newFixedThreadPool(NUM_OF_THREADS, new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread th = new Thread(r);
+                th.setName("2nd Screen BG");
+                return th;
+            }
+        });
+    }
 
     public static void runOnUI(Runnable runnable) {
         if (handler == null) {

--- a/src/com/connectsdk/service/upnp/DLNAHttpServer.java
+++ b/src/com/connectsdk/service/upnp/DLNAHttpServer.java
@@ -1,6 +1,15 @@
 package com.connectsdk.service.upnp;
 
-import android.util.Log;
+import com.connectsdk.core.MediaInfo;
+import com.connectsdk.core.Util;
+import com.connectsdk.service.capability.MediaControl.PlayStateStatus;
+import com.connectsdk.service.capability.listeners.ResponseListener;
+import com.connectsdk.service.command.URLServiceSubscription;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -14,17 +23,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.xmlpull.v1.XmlPullParserException;
-
-import com.connectsdk.core.MediaInfo;
-import com.connectsdk.core.Util;
-import com.connectsdk.service.capability.MediaControl.PlayStateStatus;
-import com.connectsdk.service.capability.listeners.ResponseListener;
-import com.connectsdk.service.command.URLServiceSubscription;
 
 public class DLNAHttpServer {
     final int port = 49291;
@@ -45,7 +43,6 @@ public class DLNAHttpServer {
         }
 
         running = true;
-        Log.d("", "SubServer start");
 
         try {
             welcomeSocket = new ServerSocket(this.port);
@@ -67,7 +64,6 @@ public class DLNAHttpServer {
             return;
         }
 
-        Log.d("", "SubServer stop");
         for (URLServiceSubscription<?> sub : subscriptions) {
             sub.unsubscribe();
         }

--- a/test/src/com/connectsdk/core/TestUtil.java
+++ b/test/src/com/connectsdk/core/TestUtil.java
@@ -1,6 +1,4 @@
-package com.connectsdk;
-
-import com.connectsdk.core.Util;
+package com.connectsdk.core;
 
 import org.apache.tools.ant.filters.StringInputStream;
 import org.mockito.Mockito;
@@ -42,5 +40,6 @@ public final class TestUtil {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+        Util.createExecutor();
     }
 }

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -2,7 +2,7 @@ package com.connectsdk.discovery.provider;
 
 import android.content.Context;
 
-import com.connectsdk.TestUtil;
+import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.DiscoveryFilter;
 import com.connectsdk.discovery.provider.ssdp.SSDPClient;
 import com.connectsdk.service.config.ServiceDescription;

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPDeviceTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPDeviceTest.java
@@ -1,6 +1,6 @@
 package com.connectsdk.discovery.provider.ssdp;
 
-import com.connectsdk.TestUtil;
+import com.connectsdk.core.TestUtil;
 
 import junit.framework.Assert;
 

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -1,8 +1,10 @@
 package com.connectsdk.service;
 
+import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.provider.ssdp.Service;
 import com.connectsdk.service.config.ServiceConfig;
 import com.connectsdk.service.config.ServiceDescription;
+import com.connectsdk.service.upnp.DLNAHttpServer;
 
 import junit.framework.Assert;
 
@@ -27,11 +29,15 @@ import java.util.Map;
 @Config(manifest=Config.NONE)
 public class DLNAServiceTest {
 
-    DLNAService service;
+    private DLNAService service;
+
+    private DLNAHttpServer dlnaServer;
 
     @Before
     public void setUp() {
-        service = new DLNAService(Mockito.mock(ServiceDescription.class), Mockito.mock(ServiceConfig.class), Robolectric.application);
+        dlnaServer = Mockito.mock(DLNAHttpServer.class);
+        service = new DLNAService(Mockito.mock(ServiceDescription.class),
+                Mockito.mock(ServiceConfig.class), Robolectric.application, dlnaServer);
     }
 
     @Test
@@ -250,6 +256,13 @@ public class DLNAServiceTest {
        Assert.assertEquals(432000000L, service.convertStrTimeFormatToLong("120:00:00"));
     }
 
+    @Test
+    public void testStopDLNAServerOnDisconnect() {
+        service.disconnect();
+        TestUtil.runUtilBackgroundTasks();
+        Mockito.verify(dlnaServer).stop();
+    }
+
     private DLNAService makeServiceWithControlURL(String base, String controlURL) {
         List<Service> services = new ArrayList<Service>();
         Service service = new Service();
@@ -260,7 +273,7 @@ public class DLNAServiceTest {
 
         ServiceDescription description = Mockito.mock(ServiceDescription.class);
         Mockito.when(description.getServiceList()).thenReturn(services);
-        return new DLNAService(description, Mockito.mock(ServiceConfig.class), Robolectric.application);
+        return new DLNAService(description, Mockito.mock(ServiceConfig.class), Robolectric.application, null);
     }
 
 }

--- a/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
+++ b/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
@@ -1,0 +1,36 @@
+package com.connectsdk.service.upnp;
+
+import com.connectsdk.service.command.URLServiceSubscription;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Created by oleksii on 4/27/15.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest=Config.NONE)
+public class DLNAHttpServerTest {
+
+    DLNAHttpServer server;
+
+    @Before
+    public void setUp() {
+        server = new DLNAHttpServer();
+    }
+
+    @Test
+    public void testUnsubscribeOnDisconnect() {
+        URLServiceSubscription<?> subscribtion = Mockito.mock(URLServiceSubscription.class);
+        server.getSubscriptions().add(subscribtion);
+        server.running = true;
+
+        server.stop();
+        Mockito.verify(subscribtion).unsubscribe();
+    }
+
+}


### PR DESCRIPTION
ConnectSDK didn't stop DLNAHttpServer when service was disconnected. This pull request changes that.