### PR TITLE
Add Loop capability into MediaPlayer

### DIFF
--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -2947,6 +2947,8 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
                 capabilities.add(PlaylistControl.JumpToTrack);
                 capabilities.add(PlaylistControl.Next);
                 capabilities.add(PlaylistControl.Previous);
+
+                capabilities.add(MediaPlayer.Loop);
             }
         }
 

--- a/src/com/connectsdk/service/capability/MediaPlayer.java
+++ b/src/com/connectsdk/service/capability/MediaPlayer.java
@@ -38,6 +38,7 @@ public interface MediaPlayer extends CapabilityMethods {
     public final static String Play_Audio = "MediaPlayer.Play.Audio";
     public final static String Play_Playlist = "MediaPlayer.Play.Playlist";
     public final static String Close = "MediaPlayer.Close";
+    public final static String Loop = "MediaPlayer.Loop";
 
     public final static String MetaData_Title = "MediaPlayer.MetaData.Title";
     public final static String MetaData_Description = "MediaPlayer.MetaData.Description";


### PR DESCRIPTION
A new capability for media loop was added here. Currently only WebOS supports it.