### PR TITLE
Fix launching web app for WebOS

### DIFF
--- a/src/com/connectsdk/service/sessions/WebOSWebAppSession.java
+++ b/src/com/connectsdk/service/sessions/WebOSWebAppSession.java
@@ -410,6 +410,7 @@ public class WebOSWebAppSession extends WebAppSession {
 
         if (socket != null) {
             socket.setListener(null);
+            socket.clearRequests();
             socket.disconnect();
             socket = null;
         }

--- a/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
+++ b/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
@@ -144,6 +144,12 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
             mListener.onCloseWithError(error);
     }
 
+    public void clearRequests() {
+        if (requests != null) {
+            requests.clear();
+        }
+    }
+
     private void setDefaultManifest() {
         manifest = new JSONObject();
         List<String> permissions = mService.getPermissions();
@@ -716,7 +722,7 @@ public class WebOSTVServiceSocketClient extends WebSocketClient implements Servi
                 Util.postError(request.getResponseListener(), new ServiceCommandError(0, "connection lost", null));
         }
 
-        requests.clear();
+        clearRequests();
     }
 
     public void setServerCertificate(X509Certificate cert) {


### PR DESCRIPTION
It fixes sending `launchWebApp` command, it should be sent only one time.