### PR TITLE
Maintain a single static instance of DiscoveryManager.

### DIFF
--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -145,7 +145,9 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      @endcode
      */
     public static synchronized void init(Context context) {
-        instance = new DiscoveryManager(context);
+        if (instance == null) {
+            instance = new DiscoveryManager(context);
+        }
     }
 
     public static synchronized void destroy() {
@@ -163,7 +165,9 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      @endcode
      */
     public static synchronized void init(Context context, ConnectableDeviceStore connectableDeviceStore) {
-        instance = new DiscoveryManager(context, connectableDeviceStore);
+        if (instance == null) {
+            instance = new DiscoveryManager(context, connectableDeviceStore);
+        }
     }
 
     /**
@@ -182,7 +186,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      * Direct use of this constructor is not recommended. In most cases,
      * you should use DiscoveryManager.getInstance() instead.
      */
-    public DiscoveryManager(Context context) {
+    private DiscoveryManager(Context context) {
         this(context, new DefaultConnectableDeviceStore(context));
     }
 
@@ -191,7 +195,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      * Direct use of this constructor is not recommended. In most cases,
      * you should use DiscoveryManager.getInstance() instead.
      */
-    public DiscoveryManager(Context context, ConnectableDeviceStore connectableDeviceStore) {
+    private DiscoveryManager(Context context, ConnectableDeviceStore connectableDeviceStore) {
         this.context = context;
         this.connectableDeviceStore = connectableDeviceStore;
 

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -29,7 +29,8 @@ public class DiscoveryManagerTest {
     
     @Before
     public void setUp() {
-        discovery = new DiscoveryManager(RuntimeEnvironment.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
+        discovery = DiscoveryManager.getInstance();
     }
     
     @Test


### PR DESCRIPTION
Consider the situation that there are 2 SDKs (SDK_A and SDK_B) using ConnectSDK. Both of them run `DiscoveryManager.init()` in their `SDK.init()` method and told their clients to run it in `Application.onCreate()`. 2 `DiscoveryManager` instances will be created in that case, and potentially leaked a `DiscoveryManager`.

This pull request will make sure there is only one single static instance of `DiscoveryManager` will be used. Event `DiscoveryManager.init()` is run twice, only one `DiscoveryManager` will be used.

Also, making `DiscoveryManager`'s constructor private can prevent clients from creating multiple instances of `DiscoveryManager`, as it is not recommended already in the original code.