### PR TITLE
- Added support for custom data in the MediaInfo object class + other fix

### DIFF
--- a/src/com/connectsdk/core/MediaInfo.java
+++ b/src/com/connectsdk/core/MediaInfo.java
@@ -39,6 +39,7 @@ public class MediaInfo {
     private String mimeType;
     private String description;
     private String title;
+    private Object customData;
 
     /**
      * list of imageInfo objects where [0] is icon, [1] is poster
@@ -61,6 +62,7 @@ public class MediaInfo {
         private String description;
         private List<ImageInfo> allImages;
         private SubtitleInfo subtitleInfo;
+        private Object customData;
 
         // @endcond
 
@@ -100,6 +102,11 @@ public class MediaInfo {
             return this;
         }
 
+        public Builder setCustomData(@NonNull Object customData) {
+            this.customData = customData;
+            return this;
+        }
+
         public MediaInfo build() {
             return new MediaInfo(this);
         }
@@ -119,6 +126,7 @@ public class MediaInfo {
         description = builder.description;
         subtitleInfo = builder.subtitleInfo;
         allImages = builder.allImages;
+        customData = builder.customData;
     }
 
     /**
@@ -272,6 +280,16 @@ public class MediaInfo {
         List<ImageInfo> list = new ArrayList<ImageInfo>();
         Collections.addAll(list, images);
         this.setImages(list);
+    }
+
+    /** Gets the raw data associated to this MediaInfo. In most cases, this is a Map or JSONObject. */
+    public Object getCustomData() {
+        return customData;
+    }
+
+    /** Sets the raw data associated to this MediaInfo.. In most cases, this is a Map or JSONObject. */
+    public void setCustomData(Object customData) {
+        this.customData = customData;
     }
 
 }

--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -129,6 +129,25 @@ public class ConnectableDevice implements DeviceServiceListener {
         setLastSeenOnWifi(json.optString(KEY_LAST_SEEN, null));
         setLastConnected(json.optLong(KEY_LAST_CONNECTED, 0));
         setLastDetection(json.optLong(KEY_LAST_DETECTED, 0));
+
+        //Deserialize the associated services as well
+        try {
+            JSONObject jsonServices = json.getJSONObject(KEY_SERVICES);
+            Iterator<?> keys = jsonServices.keys();
+            if(keys!=null) {
+                while (keys.hasNext()) {
+                    String key = (String) keys.next();
+                    if (jsonServices.get(key) instanceof JSONObject) {
+                        JSONObject serviceObject = (JSONObject) jsonServices.get(key);
+                        DeviceService service = DeviceService.getService(serviceObject);
+                        addService(service);
+                    }
+                }
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
     }
 
     public static ConnectableDevice createFromConfigString(String ipAddress, String friendlyName, String modelName, String modelNumber) {
@@ -816,6 +835,9 @@ public class ConnectableDevice implements DeviceServiceListener {
         setModelName(description.getModelName());
         setModelNumber(description.getModelNumber());
         setLastConnected(description.getLastDetection());
+
+        if(description.getUUID()!=null && description.getUUID().length()>0)
+            setId(description.getUUID());
     }
 
     public JSONObject toJSONObject() {

--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -590,16 +590,16 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
 
         compatibleDevices.put(device.getIpAddress(), device);
 
-        for (DiscoveryManagerListener listenter: discoveryListeners) {
-            listenter.onDeviceAdded(this, device);
+        for (DiscoveryManagerListener listener: discoveryListeners) {
+            listener.onDeviceAdded(this, device);
         }
     }
 
     public void handleDeviceUpdate(ConnectableDevice device) {
         if (deviceIsCompatible(device)) {
             if (device.getIpAddress() != null && compatibleDevices.containsKey(device.getIpAddress())) {
-                for (DiscoveryManagerListener listenter: discoveryListeners) {
-                    listenter.onDeviceUpdated(this, device);
+                for (DiscoveryManagerListener listener: discoveryListeners) {
+                    listener.onDeviceUpdated(this, device);
                 }
             }
             else {
@@ -613,8 +613,8 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
     }
 
     public void handleDeviceLoss(ConnectableDevice device) {
-        for (DiscoveryManagerListener listenter: discoveryListeners) {
-            listenter.onDeviceRemoved(this, device);
+        for (DiscoveryManagerListener listener: discoveryListeners) {
+            listener.onDeviceRemoved(this, device);
         }
 
         device.disconnect();
@@ -732,7 +732,6 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
 
         if (device == null) {
             device = new ConnectableDevice(serviceDescription);
-            device.setIpAddress(serviceDescription.getIpAddress());
             allDevices.put(serviceDescription.getIpAddress(), device);
             deviceIsNew = true;
         }
@@ -850,6 +849,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
         if (deviceService != null) {
             deviceService.setServiceDescription(desc);
             device.addService(deviceService);
+            device.setServiceDescription(desc);
         }
     }
     // @endcond

--- a/src/com/connectsdk/service/AirPlayService.java
+++ b/src/com/connectsdk/service/AirPlayService.java
@@ -494,6 +494,16 @@ public class AirPlayService extends DeviceService implements MediaPlayer, MediaC
 
     @Override
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         String mimeType = null;
         String title = null;

--- a/src/com/connectsdk/service/DLNAService.java
+++ b/src/com/connectsdk/service/DLNAService.java
@@ -358,8 +358,17 @@ public class DLNAService extends DeviceService implements PlaylistControl, Media
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         SubtitleInfo subtitle = null;
         String mimeType = null;

--- a/src/com/connectsdk/service/NetcastTVService.java
+++ b/src/com/connectsdk/service/NetcastTVService.java
@@ -1558,6 +1558,16 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
 
     @Override
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, final MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, final LaunchListener listener) {
         if (getDLNAService() != null) {
             final MediaPlayer.LaunchListener launchListener = new LaunchListener() {
 

--- a/src/com/connectsdk/service/RokuService.java
+++ b/src/com/connectsdk/service/RokuService.java
@@ -735,8 +735,17 @@ public class RokuService extends DeviceService implements Launcher, MediaPlayer,
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         String mimeType = null;
         String title = null;

--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -304,6 +304,11 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
         return service;
     }
 
+    @Override
+    public String getWebAppId() {
+        return MEDIA_PLAYER_ID;
+    }
+
     public static DiscoveryFilter discoveryFilter() {
         return new DiscoveryFilter(ID, "urn:lge-com:service:webos-second-screen:1");
     }
@@ -1293,8 +1298,17 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-                          MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         if ("4.0.0".equalsIgnoreCase(this.serviceDescription.getVersion())) {
             playMediaByNativeApp(mediaInfo, shouldLoop, listener);
         } else {

--- a/src/com/connectsdk/service/capability/MediaPlayer.java
+++ b/src/com/connectsdk/service/capability/MediaPlayer.java
@@ -25,6 +25,8 @@ import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceSubscription;
 import com.connectsdk.service.sessions.LaunchSession;
 
+import org.json.JSONObject;
+
 public interface MediaPlayer extends CapabilityMethods {
     public final static String Any = "MediaPlayer.Any";
 
@@ -81,6 +83,10 @@ public interface MediaPlayer extends CapabilityMethods {
     public void displayImage(MediaInfo mediaInfo, LaunchListener listener);
 
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener);
+
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener);
+
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener);
 
     public void closeMedia(LaunchSession launchSession, ResponseListener<Object> listener);
 

--- a/src/com/connectsdk/service/capability/WebAppLauncher.java
+++ b/src/com/connectsdk/service/capability/WebAppLauncher.java
@@ -59,6 +59,7 @@ public interface WebAppLauncher extends CapabilityMethods {
     };
 
     public WebAppLauncher getWebAppLauncher();
+    public String getWebAppId();
     public CapabilityPriorityLevel getWebAppLauncherCapabilityLevel();
 
     public void launchWebApp(String webAppId, LaunchListener listener);

--- a/src/com/connectsdk/service/sessions/WebAppSession.java
+++ b/src/com/connectsdk/service/sessions/WebAppSession.java
@@ -418,8 +418,17 @@ public class WebAppSession implements MediaControl, MediaPlayer, PlaylistControl
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        Util.postError(listener, ServiceCommandError.notSupported());
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, MediaPlayer.LaunchListener listener) {
+        Util.postError(listener, ServiceCommandError.notSupported());
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, MediaPlayer.LaunchListener listener) {
         Util.postError(listener, ServiceCommandError.notSupported());
     }
 

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -23,6 +23,8 @@ import com.connectsdk.BuildConfig;
 
 import junit.framework.Assert;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -54,6 +56,14 @@ public class MediaInfoTest {
         String mimeType = "video/mp4";
         String description = "description";
         String iconUrl = "http://iconurl";
+        JSONObject customData = new JSONObject(){{
+            try {
+                put("data1", 1);
+                put("data2", 2);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }};
 
         SubtitleInfo subtitle = new SubtitleInfo.Builder("").build();
         String title = "title";
@@ -63,6 +73,7 @@ public class MediaInfoTest {
                 .setIcon(iconUrl)
                 .setSubtitleInfo(subtitle)
                 .setTitle(title)
+                .setCustomData(customData)
                 .build();
 
         Assert.assertEquals(url, mediaInfo.getUrl());
@@ -72,6 +83,7 @@ public class MediaInfoTest {
         Assert.assertEquals(1, mediaInfo.getImages().size());
         Assert.assertEquals(subtitle, mediaInfo.getSubtitleInfo());
         Assert.assertEquals(title, mediaInfo.getTitle());
+        Assert.assertEquals(customData, mediaInfo.getCustomData());
     }
 
     @Test

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -22,6 +22,7 @@ package com.connectsdk.service;
 
 import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
+import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.etc.helper.HttpConnection;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
@@ -69,6 +71,7 @@ public class DLNAServiceSendCommandTest {
 
     @Before
     public void setUp() {
+        DiscoveryManager.init(RuntimeEnvironment.application);
         httpConnection = Mockito.mock(HttpConnection.class);
         service = new StubDLNAService(Mockito.mock(ServiceDescription.class),
                 Mockito.mock(ServiceConfig.class));


### PR DESCRIPTION
- Make sure the ConnectableDevice id is set with the serviceDescription UUID if any, instead of a generated one.
- Fix the ConnectableDevice constructor with a JSONObject as argument to properly initialize the serialized DeviceServices if any.
- Fix a bug where the serviceDescription does not get set to the ConnectableDevice when first discovered (was only set on the DeviceService at first, and then on the ConnectableDevice, when it get updated).
- Added Support for startPosition and customData parameters in playMedia method of MediaPlayer capability.