### PR TITLE
datagramSocket.disconnect() Deadlock

### DIFF
--- a/src/com/connectsdk/discovery/provider/ssdp/SSDPClient.java
+++ b/src/com/connectsdk/discovery/provider/ssdp/SSDPClient.java
@@ -132,7 +132,6 @@ public class SSDPClient {
         }
 
         if (datagramSocket != null) {
-            datagramSocket.disconnect();
             datagramSocket.close();
         }
     }


### PR DESCRIPTION
call to datagramSocket.disconnect() results in deadlock with receive on shutdown and is not necessary