### PR TITLE
Fix start app from DIAL

### DIFF
--- a/src/com/connectsdk/service/DIALService.java
+++ b/src/com/connectsdk/service/DIALService.java
@@ -141,7 +141,7 @@ public class DIALService extends DeviceService implements Launcher {
     public void launchAppWithInfo(final AppInfo appInfo, Object params, final AppLaunchListener listener) {
         ServiceCommand<ResponseListener<Object>> command =
                 new ServiceCommand<ResponseListener<Object>>(getCommandProcessor(),
-                        requestURL(appInfo.getName()), params, new ResponseListener<Object>() {
+                        requestURL(appInfo.getId()), params, new ResponseListener<Object>() {
             @Override
             public void onError(ServiceCommandError error) {
                 Util.postError(listener, new ServiceCommandError(0, "Problem Launching app", null));


### PR DESCRIPTION
appInfo.getId() should be used instead of appInfo.getName()
Otherwise you will get the error "Problem Launching app" on screen when launching an app by DIAL.