### PR TITLE
CA and SSL certificate support in connectSDK

### DIFF
--- a/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
+++ b/src/com/connectsdk/service/webos/WebOSTVServiceSocketClient.java
@@ -49,6 +49,9 @@ import com.connectsdk.service.command.ServiceSubscription;
 import com.connectsdk.service.command.URLServiceSubscription;
 import com.connectsdk.service.config.WebOSTVServiceConfig;
 
+import java.security.NoSuchProviderException;
+import java.security.InvalidKeyException;
+import java.security.SignatureException;
 import java.security.PublicKey;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add support to use SSL certificate for backwards compatibility in ConnectSDK

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Implemented the SSL certificates support in connectSDK

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-38706

### Comments
Enact-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)