### PR TITLE
Support SECURE pairing level for WebOSTVService

### DIFF
--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -102,7 +102,13 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
          * Specifies that pairing is on. DeviceService will try to pair if it is required by a first
          * screen device.
          */
-        ON
+        ON,
+
+        /**
+         * Specifies that pairing is secure. DeviceService will try to pair in secure mode
+         * if it is required by a first screen device (webOS - Secure Permission).
+         */
+        SECURE
     }
 
     // @cond INTERNAL

--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -352,7 +352,7 @@ public class WebOSTVService extends WebOSTVDeviceService implements Launcher, Me
 
         @Override
         public void onBeforeRegister(final PairingType pairingType) {
-            if (DiscoveryManager.getInstance().getPairingLevel() == PairingLevel.ON) {
+            if (DiscoveryManager.getInstance().getPairingLevel().compareTo(PairingLevel.ON) >= 0) {
                 Util.runOnUI(new Runnable() {
 
                     @Override


### PR DESCRIPTION
This patch supports SECURE pairing level for WebOSTVService mentioned in
Issue #117.