### PR TITLE
fixed crash when unregistering screen on/off receiver

### DIFF
--- a/src/com/connectsdk/service/webos/lgcast/screenmirroring/service/MirroringServiceEvent.java
+++ b/src/com/connectsdk/service/webos/lgcast/screenmirroring/service/MirroringServiceEvent.java
@@ -26,6 +26,7 @@ public class MirroringServiceEvent {
     private Context mContext;
     private BroadcastReceiver mScreenOnOffReceiver;
     private ContentObserver mAccessibilitySettingObserver;
+    private boolean isScreenOnOffReceiverRegistered = false;
 
     public MirroringServiceEvent(Context context) {
         if (context == null) throw new IllegalStateException("Invalid context");
@@ -50,6 +51,7 @@ public class MirroringServiceEvent {
         intentFilter.addAction(Intent.ACTION_SCREEN_ON);
         intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
         mContext.registerReceiver(mScreenOnOffReceiver, intentFilter);
+        isScreenOnOffReceiverRegistered = true;
     }
 
     public void startAccessibilitySettingObserver(AccessibilitySettingListener listener) {
@@ -66,7 +68,10 @@ public class MirroringServiceEvent {
     }
 
     public void quit() {
-        if (mScreenOnOffReceiver != null) mContext.unregisterReceiver(mScreenOnOffReceiver);
+        if (isScreenOnOffReceiverRegistered && mScreenOnOffReceiver != null) {
+            mContext.unregisterReceiver(mScreenOnOffReceiver);
+            isScreenOnOffReceiverRegistered = false;
+        }
         mScreenOnOffReceiver = null;
 
         if (mAccessibilitySettingObserver != null) mContext.getContentResolver().unregisterContentObserver(mAccessibilitySettingObserver);


### PR DESCRIPTION
Changes
Added isScreenOnOffReceiverRegistered flag to avoid unregistering a receiver that was never registered.

Reason
Previously, unregisterReceiver() was called unconditionally, causing a crash when the receiver hadn’t been registered yet.

This produced the following stack:
java.lang.IllegalArgumentException: Receiver not registered
    at android.app.LoadedApk.forgetReceiverDispatcher
    at android.app.ContextImpl.unregisterReceiver
    at com.connectsdk.service.webos.lgcast.screenmirroring.service.MirroringServiceEvent.quit
The flag ensures unregisterReceiver() is only invoked when registration actually occurred.


Testing
Verified on Android 12+ devices.